### PR TITLE
Add krew as part of the git action

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,3 +19,5 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update new version in krew-index
+        uses: rajatjindal/krew-release-bot@v0.0.36

--- a/.krew.yaml
+++ b/.krew.yaml
@@ -1,0 +1,31 @@
+apiVersion: krew.googlecontainertools.github.com/v1alpha2
+kind: Plugin
+metadata:
+  name: ipick
+spec:
+  version: v{{ .TagName }}
+  homepage: https://github.com/similarweb/kubectl-ipick
+  shortDescription: A kubectl wrapper for interactive resource selection.
+  description: |
+    This plugin is a smart wrapper around kubectl, which lets you pick 
+    the resource to act on. For example, `kubectl ipick exec` will
+    show a list of pods and execute `kubectl exec <selected-pod>`.
+  platforms:
+  - selector:
+      matchLabels:
+        os: darwin
+        arch: amd64
+    {{addURIAndSha "https://github.com/similarweb/kubectl-ipick/releases/download/v{{ .TagName }}/kubectl-ipick_{{ .TagName }}_Darwin_x86_64.tar.gz" .TagName | indent 4 }}
+    bin: kubectl-ipick
+  - selector:
+      matchLabels:
+        os: linux
+        arch: amd64
+    {{addURIAndSha "https://github.com/similarweb/kubectl-ipick/releases/download/v{{ .TagName }}/kubectl-ipick_{{ .TagName }}_Linux_x86_64.tar.gz" .TagName | indent 4 }}
+    bin: kubectl-ipick
+  - selector:
+      matchLabels:
+        os: windows
+        arch: amd64
+    {{addURIAndSha "https://github.com/similarweb/kubectl-ipick/releases/download/v{{ .TagName }}/kubectl-ipick_{{ .TagName }}_Windows_x86_64.tar.gz" .TagName | indent 4 }}    
+    bin: kubectl-ipick.exe

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Flags:
 
 Use "ipick [command] --help" for more information about a command.
 
-  ```
+```
+
 # Contributing
 All pull requests and issues are more than welcome! 
 Please see [Contribution guidelines](./CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -48,6 +48,14 @@ Recommendation: make an alias to kubectl ipick to increase the speed of your wor
 kubectl-ipick makes our day to day work with kubectl much more faster by listing the resources you wish to edit within a single command.
 ![kubectl-ipick](/docs/images/usage.gif)
 # Installation
+
+### Via krew
+Installation via krew (https://github.com/GoogleContainerTools/krew)
+
+```
+kubectl krew install ipick
+```
+
 ### Manual
 Supported OS
 ```


### PR DESCRIPTION
kubectl-ipick was added to krew-index repository (https://github.com/kubernetes-sigs/krew-index/pull/687).

The PR included: 
1. Add Krew as part of the release (git action)
2. Add Krew template
3. Add krew installation guide to the readme.md